### PR TITLE
Use .@each for non-terminal dependency keys

### DIFF
--- a/app/components/nf-graph.js
+++ b/app/components/nf-graph.js
@@ -629,7 +629,7 @@ export default Ember.Component.extend({
       yMax: Number.MIN_VALUE
     }
   */
-  dataExtents: computed('graphics.[].data', function(){
+  dataExtents: computed('graphics.@each.data', function(){
     var graphics = this.get('graphics');
     return graphics.reduce((c, x) => c.concat(x.get('mappedData')), []).reduce((extents, [x, y]) => {
       extents.xMin = extents.xMin < x ? extents.xMin : x;
@@ -736,7 +736,7 @@ export default Ember.Component.extend({
     @type Array
     @readonly
   */
-  xUniqueData: computed('graphics.[].mappedData', function(){
+  xUniqueData: computed('graphics.@each.mappedData', function(){
     var graphics = this.get('graphics');
     var uniq = graphics.reduce((uniq, graphic) => {
       return graphic.get('mappedData').reduce((uniq, d) => {
@@ -755,7 +755,7 @@ export default Ember.Component.extend({
     @type Array
     @readonly
   */
-  yUniqueData: computed('graphics.[].mappedData', function(){
+  yUniqueData: computed('graphics.@each.mappedData', function(){
     var graphics = this.get('graphics');
     var uniq = graphics.reduce((uniq, graphic) => {
       return graphic.get('mappedData').reduce((uniq, d) => {


### PR DESCRIPTION
The Ember docs aren't completely clear, but the correct usage for array dependencies is
- `foo.[]` (use `.[]` when it's at the end)
- `foo.@each.bar` (use `.@each` when it's in the middle)

Partially reverts 5dac0025c89c5975f66a0587d7cf964cf415da54

See https://github.com/emberjs/ember.js/issues/12360
