### PR TITLE
nf-graph: recompute dataExtents when data changes

### DIFF
--- a/app/components/nf-graph.js
+++ b/app/components/nf-graph.js
@@ -629,7 +629,7 @@ export default Ember.Component.extend({
       yMax: Number.MIN_VALUE
     }
   */
-  dataExtents: computed('graphics.@each.data', function(){
+  dataExtents: computed('graphics.@each.mappedData.[]', function(){
     var graphics = this.get('graphics');
     return graphics.reduce((c, x) => c.concat(x.get('mappedData')), []).reduce((extents, [x, y]) => {
       extents.xMin = extents.xMin < x ? extents.xMin : x;


### PR DESCRIPTION
Previously, it would only recompute dataExtents (and thus the axes) when the `data` array object changed to a new object. This change to the dependent key makes it also recompute whenever the _content_ of those arrays change.

See https://github.com/Netflix/ember-nf-graph/issues/108
